### PR TITLE
Autologin sqlite - resolve #18

### DIFF
--- a/src/AdminerAutologinController.php
+++ b/src/AdminerAutologinController.php
@@ -27,6 +27,7 @@ class AdminerAutologinController extends AdminerController
             $_POST['auth']['password'] = Config::get("database.connections.$database_config.password");
         }
         
+        require_once (__DIR__ . "/adminer-sqlite-login.php");
         parent::index();
     }
 

--- a/src/adminer-sqlite-login.php
+++ b/src/adminer-sqlite-login.php
@@ -1,0 +1,16 @@
+<?php
+
+if (!function_exists("adminer_object"))
+{
+    function adminer_object()
+    {
+        class AdminerSqliteLogin extends Adminer
+        {
+            public function login($ce, $G)
+            {
+                return true;
+            }
+        }
+        return new AdminerSqliteLogin;
+    }
+}    


### PR DESCRIPTION
After adminer 4.3.0 there is not possible to connect to a sqlite database without implementing a custom login method, probably for a security measure since we could connect to any database in filesystem with read permissions.

We disable this function in Laravel Autologin since here we expect the developer to protect the endpoint
in some way, not needing this second validation.

Links: https://github.com/vrana/adminer/blob/v4.3.0/adminer/include/adminer.inc.php#L110